### PR TITLE
Tos symbolic review

### DIFF
--- a/src/keymap.c
+++ b/src/keymap.c
@@ -439,6 +439,10 @@ static uint8_t Keymap_SymbolicToStScanCode_CH(const SDL_Keysym* keysym)
 	return code;
 }
 
+/* Maping for Finnish is identical to Swedish */
+static uint8_t (* const Keymap_SymbolicToStScanCode_FI)(const SDL_Keysym* keysym) =
+		Keymap_SymbolicToStScanCode_SE;
+
 static uint8_t Keymap_SymbolicToStScanCode_NO(const SDL_Keysym* keysym)
 {
 	/* TODO not yet reviewed. -- Brad Smith */
@@ -1048,19 +1052,29 @@ void Keymap_SetCountry(int countrycode)
 
 	switch (countrycode)
 	{
-	 case 1:  func = Keymap_SymbolicToStScanCode_DE; break;
-	 case 2:  func = Keymap_SymbolicToStScanCode_FR; break;
-	 case 3:  func = Keymap_SymbolicToStScanCode_UK; break;
-	 case 4:  func = Keymap_SymbolicToStScanCode_ES; break;
-	 case 5:  func = Keymap_SymbolicToStScanCode_IT; break;
-	 case 6:  func = Keymap_SymbolicToStScanCode_SE; break;
-	 case 7:  /* CHFR/CHDE share the same implementation. */
-	 case 8:  func = Keymap_SymbolicToStScanCode_CH; break;
-	 case 10: func = Keymap_SymbolicToStScanCode_SE; break; /* FI mapping is identical to SE*/
-	 case 11: func = Keymap_SymbolicToStScanCode_NO; break;
-	 case 12: func = Keymap_SymbolicToStScanCode_DK; break;
-	 case 14: func = Keymap_SymbolicToStScanCode_NL; break;
-	 default: func = Keymap_SymbolicToStScanCode_US; break; /* US default for unknown. */
+	 case TOS_LANG_US:    func = Keymap_SymbolicToStScanCode_US; break;
+	 case TOS_LANG_DE:    func = Keymap_SymbolicToStScanCode_DE; break;
+	 case TOS_LANG_FR:    func = Keymap_SymbolicToStScanCode_FR; break;
+	 case TOS_LANG_UK:    func = Keymap_SymbolicToStScanCode_UK; break;
+	 case TOS_LANG_ES:    func = Keymap_SymbolicToStScanCode_ES; break;
+	 case TOS_LANG_IT:    func = Keymap_SymbolicToStScanCode_IT; break;
+	 case TOS_LANG_SE:    func = Keymap_SymbolicToStScanCode_SE; break;
+	 case TOS_LANG_CH_FR: func = Keymap_SymbolicToStScanCode_CH; break;
+	 case TOS_LANG_CH_DE: func = Keymap_SymbolicToStScanCode_CH; break;
+	 /* case TOS_LANG_TR unimplemented */
+	 case TOS_LANG_FI:    func = Keymap_SymbolicToStScanCode_FI; break;
+	 case TOS_LANG_NO:    func = Keymap_SymbolicToStScanCode_NO; break;
+	 case TOS_LANG_DK:    func = Keymap_SymbolicToStScanCode_DK; break;
+	 /* case TOS_LANG_SA unimplemented */
+	 case TOS_LANG_NL:    func = Keymap_SymbolicToStScanCode_NL; break;
+	 /* case TOS_LANG_CS unimplemented */
+	 /* case TOS_LANG_HU unimplemented */
+	 /* case TOS_LANG_PL unimplemented */
+	 /* case TOS_LANG_RU unimplemented */
+	 /* case TOS_LANG_RO unimplemented */
+	 /* case TOS_LANG_GR unimplemented */
+	 /* US fallback for unknown. */
+	 default:             func = Keymap_SymbolicToStScanCode_US; break;
 	}
 
 	Keymap_SymbolicToStScanCode = func;

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -160,7 +160,7 @@ static uint8_t Keymap_SymbolicToStScanCode_default(const SDL_Keysym* pKeySym)
 	 case 241: code = 0x27; break; /* Ñ ES */
 	 case 242: code = 0x27; break; /* ò IT */
 	 case 246: code = 0x27; break; /* Ö DE/SE/CHDE */
-	 case 249: code = 0x28; break; /* ù FR/IT */
+	 case 249: code = 0x28; break; /* ù FR (ù IT -> 29) */
 	 case 252: code = 0x1A; break; /* Ü DE/CHDE */
 	 /* Numeric keypad: */
 	 case SDLK_KP_0: code = 0x70; break;
@@ -379,7 +379,7 @@ static uint8_t Keymap_SymbolicToStScanCode_IT(const SDL_Keysym* keysym)
 	 /* case 232: code = 0x1A; break;  è */
 	 /* case 236: code = 0x0D; break;  ì */
 	 /* case 242: code = 0x27; break;  ò */
-	 /* case 249: code = 0x29; break;  ù */
+	 case 249: code = 0x29; break; /* ù */
 	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
 	}
 	return code;

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -56,8 +56,14 @@ void Keymap_Init(void)
 
 /**
  * Default function for mapping SDL symbolic key to ST scan code.
- * This is basically the US QWERTY ST keyboard with some additional
- * international key fallbacks.
+ * This contains the ST keycode used by the majority of TOS regions for that semantic symbol.
+ * All named SDLK_* semantics can be mapped to all TOS regions.
+ * Some anonymous SDL key symbols only belong to one host keyboard region.
+ *
+ * This is a majority mapping, designed to minimize code overrides.
+ * Because it is a mismatched set, it should not be used as a default for the user.
+ * Because the US mapping is used as a default where TOS region is unknown,
+ * all majority scancode assignments that do not belong to US are marked with a comment.
  */
 static uint8_t Keymap_SymbolicToStScanCode_default(const SDL_Keysym* pKeySym)
 {
@@ -71,20 +77,20 @@ static uint8_t Keymap_SymbolicToStScanCode_default(const SDL_Keysym* pKeySym)
 	 case SDLK_RETURN: code = 0x1C; break;
 	 case SDLK_ESCAPE: code = 0x01; break;
 	 case SDLK_SPACE: code = 0x39; break;
-	 case SDLK_EXCLAIM: code = 0x09; break;     /* on azerty? */
-	 case SDLK_QUOTEDBL: code = 0x04; break;    /* on azerty? */
-	 case SDLK_HASH: code = 0x29; break;
-	 case SDLK_DOLLAR: code = 0x1b; break;      /* on azerty */
-	 case SDLK_AMPERSAND: code = 0x02; break;   /* on azerty? */
-	 case SDLK_QUOTE: code = 0x28; break;
+	 case SDLK_EXCLAIM: code = 0x02; break; /* FR host only */
+	 case SDLK_QUOTEDBL: code = 0x03; break; /* FR host only, default for DE/UK/IT/SE/CHFR/CHDE */
+	 case SDLK_HASH: code = 0x2B; break; /* DE, UK host only, default for FR/UK/ES */
+	 case SDLK_DOLLAR: code = 0x05; break; /* CHFR/CHDE host only */
+	 case SDLK_AMPERSAND: code = 0x07; break; /* ? host, default for DE/IT/SE/CHFR/CHDE */
+	 case SDLK_QUOTE: code = 0x0C; break; /* default for IT/CHFR/CHDE */
 	 case SDLK_LEFTPAREN: code = 0x63; break;
 	 case SDLK_RIGHTPAREN: code = 0x64; break;
 	 case SDLK_ASTERISK: code = 0x66; break;
-	 case SDLK_PLUS: code = 0x4e; break;
+	 case SDLK_PLUS: code = 0x0D; break;
 	 case SDLK_COMMA: code = 0x33; break;
-	 case SDLK_MINUS: code = 0x0C; break;
+	 case SDLK_MINUS: code = 0x35; break; /* default for DE/IT/SE/CHFR/CHDE */
 	 case SDLK_PERIOD: code = 0x34; break;
-	 case SDLK_SLASH: code = 0x35; break;
+	 case SDLK_SLASH: code = 0x08; break; /* default for IT/SE/CHFR/CHDE */
 	 case SDLK_0: code = 0x0B; break;
 	 case SDLK_1: code = 0x02; break;
 	 case SDLK_2: code = 0x03; break;
@@ -95,17 +101,17 @@ static uint8_t Keymap_SymbolicToStScanCode_default(const SDL_Keysym* pKeySym)
 	 case SDLK_7: code = 0x08; break;
 	 case SDLK_8: code = 0x09; break;
 	 case SDLK_9: code = 0x0A; break;
-	 case SDLK_COLON: code = 0x34; break;
-	 case SDLK_SEMICOLON: code = 0x27; break;
-	 case SDLK_LESS: code = 0x60; break;
-	 case SDLK_EQUALS: code = 0x0D; break;
-	 case SDLK_GREATER : code = 0x34; break;
-	 case SDLK_QUESTION: code = 0x35; break;
-	 case SDLK_AT: code = 0x28; break;
+	 case SDLK_COLON: code = 0x34; break; /* default for DE/FR/IT/SE/CHFR/CHDE */
+	 case SDLK_SEMICOLON: code = 0x33; break; /* default for DE/FR/IT/SE/CHFR/CHDE */
+	 case SDLK_LESS: code = 0x60; break; /* default for DE/FR/ES/IT/SE/CHFR/CHDE */
+	 case SDLK_EQUALS: code = 0x0B; break; /* default for DE/IT/SE/CHFR/CHDE */
+	 case SDLK_GREATER : code = 0x60; break; /* default for DE/FR/ES/IT/SE/CHFR/CHDE */
+	 case SDLK_QUESTION: code = 0x0C; break; /* default for DE/IT/SE/CHFR/CHDE */
+	 case SDLK_AT: code = 0x2B; break; /* default for FR/ES/SE */
 	 case SDLK_LEFTBRACKET: code = 0x1A; break;
 	 case SDLK_BACKSLASH: code = 0x2B; break;
 	 case SDLK_RIGHTBRACKET: code = 0x1B; break;
-	 case SDLK_CARET: code = 0x2B; break;
+	 case SDLK_CARET: code = 0x0D; break; /* default for IT/CHFR/CHDE */
 	 case SDLK_UNDERSCORE: code = 0x0C; break;
 	 case SDLK_BACKQUOTE: code = 0x29; break;
 	 case SDLK_a: code = 0x1E; break;
@@ -136,24 +142,26 @@ static uint8_t Keymap_SymbolicToStScanCode_default(const SDL_Keysym* pKeySym)
 	 case SDLK_z: code = 0x2C; break;
 	 case SDLK_DELETE: code = 0x53; break;
 	 /* End of ASCII mapped keysyms */
-	 case 167: code = 0x29; break;		/* Swiss § */
-	 case 168: code = 0x1B; break;		/* Swiss ¨ */
-	 case 176: code = 0x35; break;		/* Spanish ° */
-	 case 178: code = 0x29; break;		/* French ² */
-	 case 180: code = 0x0D; break;		/* German ' */
-	 case 223: code = 0x0C; break;		/* German ß */
-	 case 224: code = 0x0B; break;		/* French à */
-	 case 228: code = 0x28; break;		/* German ä */
-	 case 229: code = 0x1A; break;		/* Swedish å */
-	 case 231: code = 0x0A; break;		/* French ç */
-	 case 232: code = 0x08; break;		/* French è */
-	 case 233: code = 0x03; break;		/* French é */
-	 case 236: code = 0x0D; break;		/* Italian ì */
-	 case 241: code = 0x27; break;		/* Spanish ñ */
-	 case 242: code = 0x27; break;		/* Italian ò */
-	 case 246: code = 0x27; break;		/* German ö */
-	 case 249: code = 0x28; break;		/* French ù */
-	 case 252: code = 0x1A; break;		/* German ü */
+	 case 161: code = 0x35; break; /* ¡¿ ES as ST °§ */
+	 case 167: code = 0x29; break; /* § CHFR/CHDE (§ SE as ST \ -> 2B, no natural mapping) */
+	 case 168: code = 0x1B; break; /* ¨ SE/CHFR/CHDE as ST ü/¨/¨ */
+	 case 176: code = 0x35; break; /* ° ES as ST °§ */
+	 case 178: code = 0x29; break; /* ² FR as ST `£ (no natural mapping) */
+	 case 180: code = 0x0D; break; /* ' DE (´ SE as ST é) */
+	 case 186: code = 0x2B; break; /* º ES as ST \ */
+	 case 223: code = 0x0C; break; /* ß DE */
+	 case 224: code = 0x28; break; /* à IT/CHFR */
+	 case 228: code = 0x28; break; /* Ä DE/SE/CHDE */
+	 case 229: code = 0x1A; break; /* å SE */
+	 case 231: code = 0x29; break; /* Ç ES */
+	 case 232: code = 0x1A; break; /* è IT/CHFR */
+	 case 233: code = 0x27; break; /* é CHFR */
+	 case 236: code = 0x0D; break; /* ì IT */
+	 case 241: code = 0x27; break; /* Ñ ES */
+	 case 242: code = 0x27; break; /* ò IT */
+	 case 246: code = 0x27; break; /* Ö DE/SE/CHDE */
+	 case 249: code = 0x28; break; /* ù FR/IT */
+	 case 252: code = 0x1A; break; /* Ü DE/CHDE */
 	 /* Numeric keypad: */
 	 case SDLK_KP_0: code = 0x70; break;
 	 case SDLK_KP_1: code = 0x6D; break;
@@ -173,7 +181,7 @@ static uint8_t Keymap_SymbolicToStScanCode_default(const SDL_Keysym* pKeySym)
 	 case SDLK_KP_MINUS: code = 0x4A; break;
 	 case SDLK_KP_PLUS: code = 0x4E; break;
 	 case SDLK_KP_ENTER: code = 0x72; break;
-	 case SDLK_KP_EQUALS: code = 0x61; break;
+	 case SDLK_KP_EQUALS: code = 0x72; break; /* ST KP Enter */
 	 /* Arrows + Home/End pad */
 	 case SDLK_UP: code = 0x48; break;
 	 case SDLK_DOWN: code = 0x50; break;
@@ -181,9 +189,9 @@ static uint8_t Keymap_SymbolicToStScanCode_default(const SDL_Keysym* pKeySym)
 	 case SDLK_LEFT: code = 0x4B; break;
 	 case SDLK_INSERT: code = 0x52; break;
 	 case SDLK_HOME: code = 0x47; break;
-	 case SDLK_END: code = 0x61; break;
-	 case SDLK_PAGEUP: code = 0x63; break;
-	 case SDLK_PAGEDOWN: code = 0x64; break;
+	 case SDLK_END: code = 0x61; break; /* ST Undo */
+	 case SDLK_PAGEUP: code = 0x63; break; /* ST ( */
+	 case SDLK_PAGEDOWN: code = 0x64; break; /* ST ) */
 	 /* Function keys */
 	 case SDLK_F1: code = 0x3B; break;
 	 case SDLK_F2: code = 0x3C; break;
@@ -195,12 +203,12 @@ static uint8_t Keymap_SymbolicToStScanCode_default(const SDL_Keysym* pKeySym)
 	 case SDLK_F8: code = 0x42; break;
 	 case SDLK_F9: code = 0x43; break;
 	 case SDLK_F10: code = 0x44; break;
-	 case SDLK_F11: code = 0x62; break;
-	 case SDLK_F12: code = 0x61; break;
-	 case SDLK_F13: code = 0x62; break;
+	 case SDLK_F11: code = 0x62; break; /* ST Help */
+	 case SDLK_F12: code = 0x61; break; /* ST Undo */
+	 case SDLK_F13: code = 0x62; break; /* ST HELP */
 	 /* Key state modifier keys */
 	 case SDLK_CAPSLOCK: code = 0x3A; break;
-	 case SDLK_SCROLLLOCK: code = 0x61; break;
+	 case SDLK_SCROLLLOCK: code = 0x61; break; /* ST Undo */
 	 case SDLK_RSHIFT: code = 0x36; break;
 	 case SDLK_LSHIFT: code = 0x2A; break;
 	 case SDLK_RCTRL: code = 0x1D; break;
@@ -209,7 +217,7 @@ static uint8_t Keymap_SymbolicToStScanCode_default(const SDL_Keysym* pKeySym)
 	 case SDLK_LALT: code = 0x38; break;
 	 /* Miscellaneous function keys */
 	 case SDLK_HELP: code = 0x62; break;
-	 case SDLK_PRINTSCREEN: code = 0x62; break;
+	 case SDLK_PRINTSCREEN: code = 0x62; break; /* ST Help */
 	 case SDLK_UNDO: code = 0x61; break;
 	 default: code = ST_NO_SCANCODE;
 	}
@@ -217,108 +225,223 @@ static uint8_t Keymap_SymbolicToStScanCode_default(const SDL_Keysym* pKeySym)
 	return code;
 }
 
-static uint8_t (*Keymap_SymbolicToStScanCode)(const SDL_Keysym* pKeySym) =
-		Keymap_SymbolicToStScanCode_default;
+static uint8_t Keymap_SymbolicToStScanCode_US(const SDL_Keysym* keysym)
+{
+	uint8_t code;
+	switch (keysym->sym)
+	{
+	 case SDLK_QUOTEDBL: code = 0x28; break;
+	 case SDLK_HASH: code = 0x04; break;
+	 case SDLK_AMPERSAND: code = 0x08; break;
+	 case SDLK_QUOTE: code = 0x28; break;
+	 case SDLK_MINUS: code = 0x0C; break;
+	 case SDLK_SLASH: code = 0x35; break;
+	 case SDLK_COLON: code = 0x27; break;
+	 case SDLK_SEMICOLON: code = 0x27; break;
+	 case SDLK_LESS: code = 0x33; break;
+	 case SDLK_EQUALS: code = 0x0D; break;
+	 case SDLK_GREATER : code = 0x34; break;
+	 case SDLK_QUESTION: code = 0x35; break;
+	 case SDLK_AT: code = 0x03; break;
+	 case SDLK_CARET: code = 0x06; break;
+	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
+	}
+	return code;
+}
 
 static uint8_t Keymap_SymbolicToStScanCode_DE(const SDL_Keysym* keysym)
 {
+	uint8_t code;
 	switch (keysym->sym)
 	{
-	 case SDLK_HASH: return 0x29;
-	 case SDLK_PLUS: return 0x1B;
-	 case SDLK_MINUS: return 0x35;
-	 case SDLK_SLASH: return 0x65;
-	 case SDLK_y: return 0x2C;
-	 case SDLK_z: return 0x15;
-	 default: return Keymap_SymbolicToStScanCode_default(keysym);
+	 case SDLK_HASH: code = 0x29; break;
+	 case SDLK_QUOTE: code = 0x0D; break;
+	 case SDLK_PLUS: code = 0x1B; break;
+	 case SDLK_SLASH: code = 0x65; break;
+	 case SDLK_AT: code = 0x1A; break;
+	 case SDLK_LEFTBRACKET: code = 0x27; break;
+	 case SDLK_BACKSLASH: code = 0x1A; break;
+	 case SDLK_RIGHTBRACKET: code = 0x28; break;
+	 case SDLK_CARET: code = 0x29; break;
+	 case SDLK_UNDERSCORE: code = 0x35; break;
+	 case SDLK_BACKQUOTE: code = 0x2B; break; /* ~ | */
+	 case SDLK_y: code = 0x2C; break;
+	 case SDLK_z: code = 0x15; break;
+	 /* case 180: code = 0x0D; break;  ' */
+	 /* case 223: code = 0x0C; break;  ß */
+	 /* case 228: code = 0x28; break;  Ä */
+	 /* case 246: code = 0x27; break;  Ö */
+	 /* case 252: code = 0x1A; break;  Ü */
+	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
 	}
+	return code;
 }
 
 static uint8_t Keymap_SymbolicToStScanCode_FR(const SDL_Keysym* keysym)
 {
+	uint8_t code;
 	switch (keysym->sym)
 	{
-	 case SDLK_HASH: return 0x2B;
-	 case SDLK_QUOTE: return 0x05;
-	 case SDLK_LEFTPAREN: return 0x06;
-	 case SDLK_RIGHTPAREN: return 0x0c;
-	 case SDLK_COMMA: return 0x32;
-	 case SDLK_MINUS: return 0x0D;
-	 case SDLK_SEMICOLON: return 0x33;
-	 case SDLK_EQUALS: return 0x35;
-	 case SDLK_CARET: return 0x1A;
-	 case SDLK_a: return 0x10;
-	 case SDLK_m: return 0x27;
-	 case SDLK_q: return 0x1E;
-	 case SDLK_w: return 0x2C;
-	 case SDLK_z: return 0x11;
-	 case 167: return 0x07;		/* French § */
-	 default: return Keymap_SymbolicToStScanCode_default(keysym);
+	 case SDLK_EXCLAIM: code = 0x0D; break; /* !§ as ST -_ (no natural mapping) */
+	 case SDLK_QUOTEDBL: code = 0x04; break;
+	 case SDLK_DOLLAR: code = 0x1B; break;
+	 case SDLK_AMPERSAND: code = 0x02; break;
+	 case SDLK_QUOTE: code = 0x05; break;
+	 case SDLK_ASTERISK: code = 0x2B; break; /* *µ as ST #|@~ (2B has no natural mapping) */
+	 case SDLK_PLUS: code = 0x35; break;
+	 case SDLK_COMMA: code = 0x32; break;
+	 case SDLK_MINUS: code = 0x0D; break;
+	 case SDLK_PERIOD: code = 0x33; break;
+	 case SDLK_SLASH: code = 0x34; break;
+	 case SDLK_EQUALS: code = 0x35; break;
+	 case SDLK_QUESTION: code = 0x32; break;
+	 case SDLK_BACKSLASH: code = 0x28; break;
+	 case SDLK_CARET: code = 0x1A; break;
+	 case SDLK_UNDERSCORE: code = 0x0D; break;
+	 case SDLK_a: code = 0x10; break;
+	 case SDLK_m: code = 0x27; break;
+	 case SDLK_q: code = 0x1E; break;
+	 case SDLK_w: code = 0x2C; break;
+	 case SDLK_z: code = 0x11; break;
+	 case 167: code = 0x07; break; /* § CHFR/CHDE/SE to ST §6 */
+	 /* case 178: code = 0x29; break;  ² as ST `£ (no natural mapping) */
+	 case 224: code = 0x0B; break; /* à BÉPO FR as ST à0 */
+	 case 231: code = 0x0A; break; /* ç BÉPO FR as ST ç9 */
+	 case 232: code = 0x08; break; /* è BÉPO FR as ST è7 */
+	 case 233: code = 0x03; break; /* é BÉPO FR as ST é2 */
+	 /* case 249: code = 0x28; break;  ù */
+	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
 	}
+	return code;
 }
 
 static uint8_t Keymap_SymbolicToStScanCode_UK(const SDL_Keysym* keysym)
 {
+	uint8_t code;
 	switch (keysym->sym)
 	{
-	 case SDLK_HASH: return 0x2B;
-	 case SDLK_BACKSLASH: return 0x60;
-	 default: return Keymap_SymbolicToStScanCode_default(keysym);
+	 case SDLK_AMPERSAND: code = 0x08; break;
+	 case SDLK_QUOTE: code = 0x28; break;
+	 case SDLK_MINUS: code = 0x0C; break;
+	 case SDLK_SLASH: code = 0x35; break;
+	 case SDLK_COLON: code = 0x27; break;
+	 case SDLK_SEMICOLON: code = 0x27; break;
+	 case SDLK_LESS: code = 0x33; break;
+	 case SDLK_EQUALS: code = 0x0D; break;
+	 case SDLK_GREATER : code = 0x34; break;
+	 case SDLK_QUESTION: code = 0x35; break;
+	 case SDLK_AT: code = 0x28; break;
+	 case SDLK_BACKSLASH: code = 0x60; break;
+	 case SDLK_CARET: code = 0x06; break;
+	 case SDLK_UNDERSCORE: code = 0x0C; break;
+	 case SDLK_BACKQUOTE: code = 0x29; break;
+	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
 	}
+	return code;
 }
 
 static uint8_t Keymap_SymbolicToStScanCode_ES(const SDL_Keysym* keysym)
 {
+	uint8_t code;
 	switch (keysym->sym)
 	{
-	 case SDLK_SEMICOLON: return 0x28;
-	 case SDLK_BACKQUOTE: return 0x1B;
-	 case 231: return 0x29;		/* Spanish ç */
-	 default: return Keymap_SymbolicToStScanCode_default(keysym);
+	 case SDLK_QUOTEDBL: code = 0x1A; break;
+	 case SDLK_AMPERSAND: code = 0x08; break;
+	 case SDLK_QUOTE: code = 0x1A; break;
+	 case SDLK_MINUS: code = 0x0C; break;
+	 case SDLK_SLASH: code = 0x06; break;
+	 case SDLK_COLON: code = 0x28; break;
+	 case SDLK_SEMICOLON: code = 0x28; break;
+	 case SDLK_EQUALS: code = 0x0D; break;
+	 case SDLK_QUESTION: code = 0x33; break;
+	 case SDLK_CARET: code = 0x1B; break;
+	 case SDLK_BACKQUOTE: code = 0x1B; break;
+	 /* case 161: code = 0x35; break;  ¡¿ as ST °§ */
+	 /* case 186: code = 0x2B; break;  º as ST \ */
+	 /* case 231: code = 0x29; break;  Ç */
+	 /* case 241: code = 0x27; break;  Ñ */
+	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
 	}
+	return code;
 }
 
 static uint8_t Keymap_SymbolicToStScanCode_IT(const SDL_Keysym* keysym)
 {
+	uint8_t code;
 	switch (keysym->sym)
 	{
-	 case SDLK_QUOTE: return 0x0C;
-	 case SDLK_PLUS: return 0x1B;
-	 case SDLK_MINUS: return 0x35;
-	 case 224: return 0x28;		/* Italian à */
-	 case 232: return 0x1A;		/* Italian è */
-	 case 249: return 0x29;		/* Italian ù */
-	 default: return Keymap_SymbolicToStScanCode_default(keysym);
+	 case SDLK_HASH: code = 0x28; break;
+	 case SDLK_PLUS: code = 0x1B; break;
+	 case SDLK_AT: code = 0x27; break;
+	 case SDLK_UNDERSCORE: code = 0x35; break;
+	 case SDLK_BACKQUOTE: code = 0x60; break;
+	 /* case 224: code = 0x28; break;  à */
+	 /* case 232: code = 0x1A; break;  è */
+	 /* case 236: code = 0x0D; break;  ì */
+	 /* case 242: code = 0x27; break;  ò */
+	 /* case 249: code = 0x29; break;  ù */
+	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
 	}
+	return code;
 }
 
 static uint8_t Keymap_SymbolicToStScanCode_SE(const SDL_Keysym* keysym)
 {
+	uint8_t code;
 	switch (keysym->sym)
 	{
-	 case SDLK_QUOTE: return 0x29;
-	 case SDLK_PLUS: return 0x0C;
-	 case SDLK_MINUS: return 0x35;
-	 case 252: return 0x1b;		/* ü */
-	 default: return Keymap_SymbolicToStScanCode_default(keysym);
+	 case SDLK_HASH: code = 0x04; break;
+	 case SDLK_QUOTE: code = 0x29; break;
+	 case SDLK_ASTERISK: code = 0x29; break;
+	 case SDLK_PLUS: code = 0x0C; break;
+	 case SDLK_CARET: code = 0x2B; break;
+	 case SDLK_UNDERSCORE: code = 0x35; break;
+	 case SDLK_BACKQUOTE: code = 0x28; break;
+	 case 167: code = 0x2B; break; /* § as ST \ (no natural mapping) */
+	 /* case 168: code = 0x1B; break;  ¨ as ST ü */
+	 /* case 180: code = 0x0D; break;  ´ as ST é */
+	 /* case 228: code = 0x28; break;  ä */
+	 /* case 229: code = 0x1A; break;  å */
+	 /* case 246: code = 0x27; break;  ö */
+	 case 252: code = 0x1B; break; /* Ü DE/CHDE */
+	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
 	}
+	return code;
 }
 
 /* Mapping for both, French and German variant of Swiss keyboard */
 static uint8_t Keymap_SymbolicToStScanCode_CH(const SDL_Keysym* keysym)
 {
+	uint8_t code;
 	switch (keysym->sym)
 	{
-	 case SDLK_CARET: return 0x0D;
-	 case 224: return 0x28;		/* à */
-	 case 232: return 0x1A;		/* è */
-	 case 233: return 0x27;		/* é */
-	 default: return Keymap_SymbolicToStScanCode_default(keysym);
+	 case SDLK_EXCLAIM: code = 0x1B; break;
+	 case SDLK_HASH: code = 0x1B; break;
+	 case SDLK_DOLLAR: code = 0x2B; break;
+	 case SDLK_ASTERISK: code = 0x04; break;
+	 case SDLK_PLUS: code = 0x02; break;
+	 case SDLK_AT: code = 0x1A; break;
+	 case SDLK_LEFTBRACKET: code = 0x27; break;
+	 case SDLK_BACKSLASH: code = 0x1A; break;
+	 case SDLK_RIGHTBRACKET: code = 0x28; break;
+	 case SDLK_UNDERSCORE: code = 0x35; break;
+	 case SDLK_BACKQUOTE: code = 0x0D; break;
+	 /* case 167: code = 0x29; break;  § */
+	 /* case 168: code = 0x1B; break;  ¨ */
+	 /* case 224: code = 0x28; break;  CHFR à */
+	 /* case 228: code = 0x28; break;  CHDE ä */
+	 /* case 232: code = 0x1A; break;  CHFR è */
+	 /* case 233: code = 0x27; break;  CHFR é */
+	 /* case 246: code = 0x27; break;  CHDE ö */
+	 /* case 252: code = 0x1A; break;  CHDE ü */
+	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
 	}
+	return code;
 }
 
 static uint8_t Keymap_SymbolicToStScanCode_NO(const SDL_Keysym* keysym)
 {
+	/* TODO not yet reviewed. -- Brad Smith */
 	switch (keysym->sym)
 	{
 	 case SDLK_QUOTE: return 0x29;
@@ -334,6 +457,7 @@ static uint8_t Keymap_SymbolicToStScanCode_NO(const SDL_Keysym* keysym)
 
 static uint8_t Keymap_SymbolicToStScanCode_DK(const SDL_Keysym* keysym)
 {
+	/* TODO not yet reviewed. -- Brad Smith */
 	switch (keysym->sym)
 	{
 	 case SDLK_QUOTE: return 0x0D;
@@ -349,6 +473,7 @@ static uint8_t Keymap_SymbolicToStScanCode_DK(const SDL_Keysym* keysym)
 
 static uint8_t Keymap_SymbolicToStScanCode_NL(const SDL_Keysym* keysym)
 {
+	/* TODO not yet reviewed. -- Brad Smith */
 	switch (keysym->sym)
 	{
 	 case SDLK_HASH: return 0x2B;
@@ -356,6 +481,9 @@ static uint8_t Keymap_SymbolicToStScanCode_NL(const SDL_Keysym* keysym)
 	 default: return Keymap_SymbolicToStScanCode_default(keysym);
 	}
 }
+
+static uint8_t (*Keymap_SymbolicToStScanCode)(const SDL_Keysym* pKeySym) =
+		Keymap_SymbolicToStScanCode_US;
 
 /**
  * Remap SDL scancode key to ST Scan code
@@ -925,14 +1053,14 @@ void Keymap_SetCountry(int countrycode)
 	 case 3:  func = Keymap_SymbolicToStScanCode_UK; break;
 	 case 4:  func = Keymap_SymbolicToStScanCode_ES; break;
 	 case 5:  func = Keymap_SymbolicToStScanCode_IT; break;
-	 case 10: /* Finish seems to be the same as Swedish */
 	 case 6:  func = Keymap_SymbolicToStScanCode_SE; break;
-	 case 7:
+	 case 7:  /* CHFR/CHDE share the same implementation. */
 	 case 8:  func = Keymap_SymbolicToStScanCode_CH; break;
+	 case 10: func = Keymap_SymbolicToStScanCode_SE; break; /* FI mapping is identical to SE*/
 	 case 11: func = Keymap_SymbolicToStScanCode_NO; break;
 	 case 12: func = Keymap_SymbolicToStScanCode_DK; break;
 	 case 14: func = Keymap_SymbolicToStScanCode_NL; break;
-	 default: func = Keymap_SymbolicToStScanCode_default; break;
+	 default: func = Keymap_SymbolicToStScanCode_US; break; /* US default for unknown. */
 	}
 
 	Keymap_SymbolicToStScanCode = func;

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -56,20 +56,19 @@ void Keymap_Init(void)
 
 /**
  * Default function for mapping SDL symbolic key to ST scan code.
- * This contains the ST keycode used by the majority of TOS regions for that semantic symbol.
- * All named SDLK_* semantics can be mapped to all TOS regions.
- * Some anonymous SDL key symbols only belong to one host keyboard region.
+ * This is a mapping for US layout host keyboard to US TOS scan code.
  *
- * This is a majority mapping, designed to minimize code overrides.
- * Because it is a mismatched set, it should not be used as a default for the user.
- * Because the US mapping is used as a default where TOS region is unknown,
- * all majority scancode assignments that do not belong to US are marked with a comment.
+ * Other TOS language mappings will provide a set of overrides,
+ * before calling this map.
+ *
+ * Additional anonymous SDL symbolic mappings are included here,
+ * which generally represent extra keys present for one or two host languages,
+ * not necessarily used by the US mapping.
  */
-static uint8_t Keymap_SymbolicToStScanCode_default(const SDL_Keysym* pKeySym)
+static uint8_t Keymap_SymbolicToStScanCode_US(const SDL_Keysym* keysym)
 {
 	uint8_t code;
-
-	switch (pKeySym->sym)
+	switch (keysym->sym)
 	{
 	 case SDLK_BACKSPACE: code = 0x0E; break;
 	 case SDLK_TAB: code = 0x0F; break;
@@ -78,19 +77,19 @@ static uint8_t Keymap_SymbolicToStScanCode_default(const SDL_Keysym* pKeySym)
 	 case SDLK_ESCAPE: code = 0x01; break;
 	 case SDLK_SPACE: code = 0x39; break;
 	 case SDLK_EXCLAIM: code = 0x02; break; /* FR host only */
-	 case SDLK_QUOTEDBL: code = 0x03; break; /* FR host only, default for DE/UK/IT/SE/CHFR/CHDE */
-	 case SDLK_HASH: code = 0x2B; break; /* DE, UK host only, default for FR/UK/ES */
+	 case SDLK_QUOTEDBL: code = 0x28; break;/* FR host only */
+	 case SDLK_HASH: code = 0x04; break; /* DE, UK host only */
 	 case SDLK_DOLLAR: code = 0x05; break; /* CHFR/CHDE host only */
-	 case SDLK_AMPERSAND: code = 0x07; break; /* ? host, default for DE/IT/SE/CHFR/CHDE */
-	 case SDLK_QUOTE: code = 0x0C; break; /* default for IT/CHFR/CHDE */
+	 case SDLK_AMPERSAND: code = 0x08; break; /* ? host */
+	 case SDLK_QUOTE: code = 0x28; break;
 	 case SDLK_LEFTPAREN: code = 0x63; break;
 	 case SDLK_RIGHTPAREN: code = 0x64; break;
 	 case SDLK_ASTERISK: code = 0x66; break;
 	 case SDLK_PLUS: code = 0x0D; break;
 	 case SDLK_COMMA: code = 0x33; break;
-	 case SDLK_MINUS: code = 0x35; break; /* default for DE/IT/SE/CHFR/CHDE */
+	 case SDLK_MINUS: code = 0x0C; break;
 	 case SDLK_PERIOD: code = 0x34; break;
-	 case SDLK_SLASH: code = 0x08; break; /* default for IT/SE/CHFR/CHDE */
+	 case SDLK_SLASH: code = 0x35; break;
 	 case SDLK_0: code = 0x0B; break;
 	 case SDLK_1: code = 0x02; break;
 	 case SDLK_2: code = 0x03; break;
@@ -101,17 +100,17 @@ static uint8_t Keymap_SymbolicToStScanCode_default(const SDL_Keysym* pKeySym)
 	 case SDLK_7: code = 0x08; break;
 	 case SDLK_8: code = 0x09; break;
 	 case SDLK_9: code = 0x0A; break;
-	 case SDLK_COLON: code = 0x34; break; /* default for DE/FR/IT/SE/CHFR/CHDE */
-	 case SDLK_SEMICOLON: code = 0x33; break; /* default for DE/FR/IT/SE/CHFR/CHDE */
-	 case SDLK_LESS: code = 0x60; break; /* default for DE/FR/ES/IT/SE/CHFR/CHDE */
-	 case SDLK_EQUALS: code = 0x0B; break; /* default for DE/IT/SE/CHFR/CHDE */
-	 case SDLK_GREATER : code = 0x60; break; /* default for DE/FR/ES/IT/SE/CHFR/CHDE */
-	 case SDLK_QUESTION: code = 0x0C; break; /* default for DE/IT/SE/CHFR/CHDE */
-	 case SDLK_AT: code = 0x2B; break; /* default for FR/ES/SE */
+	 case SDLK_COLON: code = 0x27; break;
+	 case SDLK_SEMICOLON: code = 0x27; break;
+	 case SDLK_LESS: code = 0x33; break;
+	 case SDLK_EQUALS: code = 0x0D; break;
+	 case SDLK_GREATER: code = 0x34; break;
+	 case SDLK_QUESTION: code = 0x35; break;
+	 case SDLK_AT: code = 0x03; break;
 	 case SDLK_LEFTBRACKET: code = 0x1A; break;
 	 case SDLK_BACKSLASH: code = 0x2B; break;
 	 case SDLK_RIGHTBRACKET: code = 0x1B; break;
-	 case SDLK_CARET: code = 0x0D; break; /* default for IT/CHFR/CHDE */
+	 case SDLK_CARET: code = 0x06; break;
 	 case SDLK_UNDERSCORE: code = 0x0C; break;
 	 case SDLK_BACKQUOTE: code = 0x29; break;
 	 case SDLK_a: code = 0x1E; break;
@@ -225,39 +224,24 @@ static uint8_t Keymap_SymbolicToStScanCode_default(const SDL_Keysym* pKeySym)
 	return code;
 }
 
-static uint8_t Keymap_SymbolicToStScanCode_US(const SDL_Keysym* keysym)
-{
-	uint8_t code;
-	switch (keysym->sym)
-	{
-	 case SDLK_QUOTEDBL: code = 0x28; break;
-	 case SDLK_HASH: code = 0x04; break;
-	 case SDLK_AMPERSAND: code = 0x08; break;
-	 case SDLK_QUOTE: code = 0x28; break;
-	 case SDLK_MINUS: code = 0x0C; break;
-	 case SDLK_SLASH: code = 0x35; break;
-	 case SDLK_COLON: code = 0x27; break;
-	 case SDLK_SEMICOLON: code = 0x27; break;
-	 case SDLK_LESS: code = 0x33; break;
-	 case SDLK_EQUALS: code = 0x0D; break;
-	 case SDLK_GREATER : code = 0x34; break;
-	 case SDLK_QUESTION: code = 0x35; break;
-	 case SDLK_AT: code = 0x03; break;
-	 case SDLK_CARET: code = 0x06; break;
-	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
-	}
-	return code;
-}
-
 static uint8_t Keymap_SymbolicToStScanCode_DE(const SDL_Keysym* keysym)
 {
 	uint8_t code;
 	switch (keysym->sym)
 	{
+	 case SDLK_QUOTEDBL: code = 0x03; break;
 	 case SDLK_HASH: code = 0x29; break;
+	 case SDLK_AMPERSAND: code = 0x07; break;
 	 case SDLK_QUOTE: code = 0x0D; break;
 	 case SDLK_PLUS: code = 0x1B; break;
+	 case SDLK_MINUS: code = 0x35; break;
 	 case SDLK_SLASH: code = 0x65; break;
+	 case SDLK_COLON: code = 0x34; break;
+	 case SDLK_SEMICOLON: code = 0x33; break;
+	 case SDLK_LESS: code = 0x60; break;
+	 case SDLK_EQUALS: code = 0x0B; break;
+	 case SDLK_GREATER: code = 0x60; break;
+	 case SDLK_QUESTION: code = 0x0C; break;
 	 case SDLK_AT: code = 0x1A; break;
 	 case SDLK_LEFTBRACKET: code = 0x27; break;
 	 case SDLK_BACKSLASH: code = 0x1A; break;
@@ -272,7 +256,7 @@ static uint8_t Keymap_SymbolicToStScanCode_DE(const SDL_Keysym* keysym)
 	 /* case 228: code = 0x28; break;  Ä */
 	 /* case 246: code = 0x27; break;  Ö */
 	 /* case 252: code = 0x1A; break;  Ü */
-	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
+	 default: code = Keymap_SymbolicToStScanCode_US(keysym);
 	}
 	return code;
 }
@@ -284,6 +268,7 @@ static uint8_t Keymap_SymbolicToStScanCode_FR(const SDL_Keysym* keysym)
 	{
 	 case SDLK_EXCLAIM: code = 0x0D; break; /* !§ as ST -_ (no natural mapping) */
 	 case SDLK_QUOTEDBL: code = 0x04; break;
+	 case SDLK_HASH: code = 0x2B; break;
 	 case SDLK_DOLLAR: code = 0x1B; break;
 	 case SDLK_AMPERSAND: code = 0x02; break;
 	 case SDLK_QUOTE: code = 0x05; break;
@@ -293,8 +278,13 @@ static uint8_t Keymap_SymbolicToStScanCode_FR(const SDL_Keysym* keysym)
 	 case SDLK_MINUS: code = 0x0D; break;
 	 case SDLK_PERIOD: code = 0x33; break;
 	 case SDLK_SLASH: code = 0x34; break;
+	 case SDLK_COLON: code = 0x34; break;
+	 case SDLK_SEMICOLON: code = 0x33; break;
+	 case SDLK_LESS: code = 0x60; break;
 	 case SDLK_EQUALS: code = 0x35; break;
+	 case SDLK_GREATER: code = 0x60; break;
 	 case SDLK_QUESTION: code = 0x32; break;
+	 case SDLK_AT: code = 0x2B; break;
 	 case SDLK_BACKSLASH: code = 0x28; break;
 	 case SDLK_CARET: code = 0x1A; break;
 	 case SDLK_UNDERSCORE: code = 0x0D; break;
@@ -310,7 +300,7 @@ static uint8_t Keymap_SymbolicToStScanCode_FR(const SDL_Keysym* keysym)
 	 case 232: code = 0x08; break; /* è IT/CHFR or BÉPO FR as ST è7 */
 	 case 233: code = 0x03; break; /* é CHFR or BÉPO FR as ST é2 */
 	 /* case 249: code = 0x28; break;  ù */
-	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
+	 default: code = Keymap_SymbolicToStScanCode_US(keysym);
 	}
 	return code;
 }
@@ -320,6 +310,8 @@ static uint8_t Keymap_SymbolicToStScanCode_UK(const SDL_Keysym* keysym)
 	uint8_t code;
 	switch (keysym->sym)
 	{
+	 case SDLK_QUOTEDBL: code = 0x03; break;
+	 case SDLK_HASH: code = 0x2B; break;
 	 case SDLK_AMPERSAND: code = 0x08; break;
 	 case SDLK_QUOTE: code = 0x28; break;
 	 case SDLK_MINUS: code = 0x0C; break;
@@ -335,7 +327,7 @@ static uint8_t Keymap_SymbolicToStScanCode_UK(const SDL_Keysym* keysym)
 	 case SDLK_CARET: code = 0x06; break;
 	 case SDLK_UNDERSCORE: code = 0x0C; break;
 	 case SDLK_BACKQUOTE: code = 0x29; break;
-	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
+	 default: code = Keymap_SymbolicToStScanCode_US(keysym);
 	}
 	return code;
 }
@@ -346,21 +338,25 @@ static uint8_t Keymap_SymbolicToStScanCode_ES(const SDL_Keysym* keysym)
 	switch (keysym->sym)
 	{
 	 case SDLK_QUOTEDBL: code = 0x1A; break;
+	 case SDLK_HASH: code = 0x2B; break;
 	 case SDLK_AMPERSAND: code = 0x08; break;
 	 case SDLK_QUOTE: code = 0x1A; break;
 	 case SDLK_MINUS: code = 0x0C; break;
 	 case SDLK_SLASH: code = 0x06; break;
 	 case SDLK_COLON: code = 0x28; break;
 	 case SDLK_SEMICOLON: code = 0x28; break;
+	 case SDLK_LESS: code = 0x60; break;
 	 case SDLK_EQUALS: code = 0x0D; break;
+	 case SDLK_GREATER: code = 0x60; break;
 	 case SDLK_QUESTION: code = 0x33; break;
+	 case SDLK_AT: code = 0x2B; break;
 	 case SDLK_CARET: code = 0x1B; break;
 	 case SDLK_BACKQUOTE: code = 0x1B; break;
 	 /* case 161: code = 0x35; break;  ¡¿ as ST °§ */
 	 /* case 186: code = 0x2B; break;  º as ST \ */
 	 /* case 231: code = 0x29; break;  Ç */
 	 /* case 241: code = 0x27; break;  Ñ */
-	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
+	 default: code = Keymap_SymbolicToStScanCode_US(keysym);
 	}
 	return code;
 }
@@ -370,9 +366,21 @@ static uint8_t Keymap_SymbolicToStScanCode_IT(const SDL_Keysym* keysym)
 	uint8_t code;
 	switch (keysym->sym)
 	{
+	 case SDLK_QUOTEDBL: code = 0x03; break;
 	 case SDLK_HASH: code = 0x28; break;
+	 case SDLK_AMPERSAND: code = 0x07; break;
+	 case SDLK_QUOTE: code = 0x0C; break;
 	 case SDLK_PLUS: code = 0x1B; break;
+	 case SDLK_MINUS: code = 0x35; break;
+	 case SDLK_SLASH: code = 0x08; break;
+	 case SDLK_COLON: code = 0x34; break;
+	 case SDLK_SEMICOLON: code = 0x33; break;
+	 case SDLK_LESS: code = 0x60; break;
+	 case SDLK_EQUALS: code = 0x0B; break;
+	 case SDLK_GREATER: code = 0x60; break;
+	 case SDLK_QUESTION: code = 0x0C; break;
 	 case SDLK_AT: code = 0x27; break;
+	 case SDLK_CARET: code = 0x0D; break;
 	 case SDLK_UNDERSCORE: code = 0x35; break;
 	 case SDLK_BACKQUOTE: code = 0x60; break;
 	 /* case 224: code = 0x28; break;  à */
@@ -380,7 +388,7 @@ static uint8_t Keymap_SymbolicToStScanCode_IT(const SDL_Keysym* keysym)
 	 /* case 236: code = 0x0D; break;  ì */
 	 /* case 242: code = 0x27; break;  ò */
 	 case 249: code = 0x29; break; /* ù */
-	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
+	 default: code = Keymap_SymbolicToStScanCode_US(keysym);
 	}
 	return code;
 }
@@ -390,10 +398,21 @@ static uint8_t Keymap_SymbolicToStScanCode_SE(const SDL_Keysym* keysym)
 	uint8_t code;
 	switch (keysym->sym)
 	{
+	 case SDLK_QUOTEDBL: code = 0x03; break;
 	 case SDLK_HASH: code = 0x04; break;
+	 case SDLK_AMPERSAND: code = 0x07; break;
 	 case SDLK_QUOTE: code = 0x29; break;
 	 case SDLK_ASTERISK: code = 0x29; break;
 	 case SDLK_PLUS: code = 0x0C; break;
+	 case SDLK_MINUS: code = 0x35; break;
+	 case SDLK_SLASH: code = 0x08; break;
+	 case SDLK_COLON: code = 0x34; break;
+	 case SDLK_SEMICOLON: code = 0x33; break;
+	 case SDLK_LESS: code = 0x60; break;
+	 case SDLK_EQUALS: code = 0x0B; break;
+	 case SDLK_GREATER: code = 0x60; break;
+	 case SDLK_QUESTION: code = 0x0C; break;
+	 case SDLK_AT: code = 0x2B; break;
 	 case SDLK_CARET: code = 0x2B; break;
 	 case SDLK_UNDERSCORE: code = 0x35; break;
 	 case SDLK_BACKQUOTE: code = 0x28; break;
@@ -404,7 +423,7 @@ static uint8_t Keymap_SymbolicToStScanCode_SE(const SDL_Keysym* keysym)
 	 /* case 229: code = 0x1A; break;  å */
 	 /* case 246: code = 0x27; break;  ö */
 	 case 252: code = 0x1B; break; /* Ü DE/CHDE */
-	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
+	 default: code = Keymap_SymbolicToStScanCode_US(keysym);
 	}
 	return code;
 }
@@ -416,11 +435,23 @@ static uint8_t Keymap_SymbolicToStScanCode_CH(const SDL_Keysym* keysym)
 	switch (keysym->sym)
 	{
 	 case SDLK_EXCLAIM: code = 0x1B; break;
+	 case SDLK_QUOTEDBL: code = 0x03; break;
 	 case SDLK_HASH: code = 0x1B; break;
 	 case SDLK_DOLLAR: code = 0x2B; break;
+	 case SDLK_AMPERSAND: code = 0x07; break;
+	 case SDLK_QUOTE: code = 0x0C; break;
 	 case SDLK_ASTERISK: code = 0x04; break;
 	 case SDLK_PLUS: code = 0x02; break;
+	 case SDLK_MINUS: code = 0x35; break;
+	 case SDLK_SLASH: code = 0x08; break;
+	 case SDLK_COLON: code = 0x34; break;
+	 case SDLK_SEMICOLON: code = 0x33; break;
+	 case SDLK_LESS: code = 0x60; break;
+	 case SDLK_EQUALS: code = 0x0B; break;
+	 case SDLK_GREATER: code = 0x60; break;
+	 case SDLK_QUESTION: code = 0x0C; break;
 	 case SDLK_AT: code = 0x1A; break;
+	 case SDLK_CARET: code = 0x0D; break;
 	 case SDLK_LEFTBRACKET: code = 0x27; break;
 	 case SDLK_BACKSLASH: code = 0x1A; break;
 	 case SDLK_RIGHTBRACKET: code = 0x28; break;
@@ -434,7 +465,7 @@ static uint8_t Keymap_SymbolicToStScanCode_CH(const SDL_Keysym* keysym)
 	 /* case 233: code = 0x27; break;  CHFR é */
 	 /* case 246: code = 0x27; break;  CHDE ö */
 	 /* case 252: code = 0x1A; break;  CHDE ü */
-	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
+	 default: code = Keymap_SymbolicToStScanCode_US(keysym);
 	}
 	return code;
 }
@@ -452,14 +483,8 @@ static uint8_t Keymap_SymbolicToStScanCode_NO(const SDL_Keysym* keysym)
 	 case SDLK_HASH: return 0x29;
 	 case SDLK_DOLLAR: return 0x1B;
 	 case SDLK_AMPERSAND: return 0x02;
-	 /*case SDLK_QUOTE: return 0x28;*/
-	 /*case SDLK_PLUS: return 0x4E;*/
-	 /*case SDLK_MINUS: return 0x0C;*/
-	 case SDLK_SLASH: return 0x35;
-	 case SDLK_SEMICOLON: return 0x27;
-	 case SDLK_EQUALS: return 0x0D;
-	 case SDLK_GREATER: return 0x34;
-	 case SDLK_QUESTION: return 0x35;
+	 case SDLK_COLON: return 0x34;
+	 case SDLK_LESS: return 0x60;
 	 case SDLK_AT: return 0x28;
 	 case SDLK_CARET: return 0x2B;
 	 /* TODO not yet reviewed. The cases above ensure no changes from Thomas Huth's default map and should be re-evaluated on review. -- Brad Smith */
@@ -470,7 +495,7 @@ static uint8_t Keymap_SymbolicToStScanCode_NO(const SDL_Keysym* keysym)
 	 case 233: return 0x0D;		/* é */
 	 case 248: return 0x27;		/* ø */
 	 case 252: return 0x1b;		/* ü */
-	 default: return Keymap_SymbolicToStScanCode_default(keysym);
+	 default: return Keymap_SymbolicToStScanCode_US(keysym);
 	}
 }
 
@@ -483,14 +508,8 @@ static uint8_t Keymap_SymbolicToStScanCode_DK(const SDL_Keysym* keysym)
 	 case SDLK_HASH: return 0x29;
 	 case SDLK_DOLLAR: return 0x1B;
 	 case SDLK_AMPERSAND: return 0x02;
-	 /*case SDLK_QUOTE: return 0x28;*/
-	 /*case SDLK_PLUS: return 0x4E;*/
-	 /*case SDLK_MINUS: return 0x0C;*/
-	 case SDLK_SLASH: return 0x35;
-	 case SDLK_SEMICOLON: return 0x27;
-	 case SDLK_EQUALS: return 0x0D;
-	 case SDLK_GREATER: return 0x34;
-	 case SDLK_QUESTION: return 0x35;
+	 case SDLK_COLON: return 0x34;
+	 case SDLK_LESS: return 0x60;
 	 case SDLK_AT: return 0x28;
 	 case SDLK_CARET: return 0x2B;
 	 /* TODO not yet reviewed. The cases above ensure no changes from Thomas Huth's default map and should be re-evaluated on review. -- Brad Smith */
@@ -501,7 +520,7 @@ static uint8_t Keymap_SymbolicToStScanCode_DK(const SDL_Keysym* keysym)
 	 case 230: return 0x27;		/* æ */
 	 case 233: return 0x29;		/* é */
 	 case 248: return 0x28;		/* ø */
-	 default: return Keymap_SymbolicToStScanCode_default(keysym);
+	 default: return Keymap_SymbolicToStScanCode_US(keysym);
 	}
 }
 
@@ -511,23 +530,17 @@ static uint8_t Keymap_SymbolicToStScanCode_NL(const SDL_Keysym* keysym)
 	{
 	 case SDLK_EXCLAIM: return 0x09;
 	 case SDLK_QUOTEDBL: return 0x04;
-	 /*case SDLK_HASH: return 0x29;*/
 	 case SDLK_DOLLAR: return 0x1B;
 	 case SDLK_AMPERSAND: return 0x02;
-	 case SDLK_QUOTE: return 0x28;
 	 case SDLK_PLUS: return 0x4E;
-	 case SDLK_MINUS: return 0x0C;
-	 case SDLK_SLASH: return 0x35;
-	 case SDLK_SEMICOLON: return 0x27;
-	 case SDLK_EQUALS: return 0x0D;
-	 case SDLK_GREATER: return 0x34;
-	 case SDLK_QUESTION: return 0x35;
+	 case SDLK_COLON: return 0x34;
+	 case SDLK_LESS: return 0x60;
 	 case SDLK_AT: return 0x28;
 	 case SDLK_CARET: return 0x2B;
 	 /* TODO not yet reviewed. The cases above ensure no changes from Thomas Huth's default map and should be re-evaluated on review. -- Brad Smith */
 	 case SDLK_HASH: return 0x2B;
 	 case SDLK_BACKSLASH: return 0x60;
-	 default: return Keymap_SymbolicToStScanCode_default(keysym);
+	 default: return Keymap_SymbolicToStScanCode_US(keysym);
 	}
 }
 

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -305,10 +305,10 @@ static uint8_t Keymap_SymbolicToStScanCode_FR(const SDL_Keysym* keysym)
 	 case SDLK_z: code = 0x11; break;
 	 case 167: code = 0x07; break; /* § CHFR/CHDE/SE to ST §6 */
 	 /* case 178: code = 0x29; break;  ² as ST `£ (no natural mapping) */
-	 case 224: code = 0x0B; break; /* à BÉPO FR as ST à0 */
-	 case 231: code = 0x0A; break; /* ç BÉPO FR as ST ç9 */
-	 case 232: code = 0x08; break; /* è BÉPO FR as ST è7 */
-	 case 233: code = 0x03; break; /* é BÉPO FR as ST é2 */
+	 case 224: code = 0x0B; break; /* à IT/CHFR or BÉPO FR as ST à0 */
+	 case 231: code = 0x0A; break; /* ç ES or BÉPO FR as ST ç9 */
+	 case 232: code = 0x08; break; /* è IT/CHFR or BÉPO FR as ST è7 */
+	 case 233: code = 0x03; break; /* é CHFR or BÉPO FR as ST é2 */
 	 /* case 249: code = 0x28; break;  ù */
 	 default: code = Keymap_SymbolicToStScanCode_default(keysym);
 	}

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -445,9 +445,24 @@ static uint8_t (* const Keymap_SymbolicToStScanCode_FI)(const SDL_Keysym* keysym
 
 static uint8_t Keymap_SymbolicToStScanCode_NO(const SDL_Keysym* keysym)
 {
-	/* TODO not yet reviewed. -- Brad Smith */
 	switch (keysym->sym)
 	{
+	 case SDLK_EXCLAIM: return 0x09;
+	 case SDLK_QUOTEDBL: return 0x04;
+	 case SDLK_HASH: return 0x29;
+	 case SDLK_DOLLAR: return 0x1B;
+	 case SDLK_AMPERSAND: return 0x02;
+	 /*case SDLK_QUOTE: return 0x28;*/
+	 /*case SDLK_PLUS: return 0x4E;*/
+	 /*case SDLK_MINUS: return 0x0C;*/
+	 case SDLK_SLASH: return 0x35;
+	 case SDLK_SEMICOLON: return 0x27;
+	 case SDLK_EQUALS: return 0x0D;
+	 case SDLK_GREATER: return 0x34;
+	 case SDLK_QUESTION: return 0x35;
+	 case SDLK_AT: return 0x28;
+	 case SDLK_CARET: return 0x2B;
+	 /* TODO not yet reviewed. The cases above ensure no changes from Thomas Huth's default map and should be re-evaluated on review. -- Brad Smith */
 	 case SDLK_QUOTE: return 0x29;
 	 case SDLK_PLUS: return 0x0C;
 	 case SDLK_MINUS: return 0x35;
@@ -461,9 +476,24 @@ static uint8_t Keymap_SymbolicToStScanCode_NO(const SDL_Keysym* keysym)
 
 static uint8_t Keymap_SymbolicToStScanCode_DK(const SDL_Keysym* keysym)
 {
-	/* TODO not yet reviewed. -- Brad Smith */
 	switch (keysym->sym)
 	{
+	 case SDLK_EXCLAIM: return 0x09;
+	 case SDLK_QUOTEDBL: return 0x04;
+	 case SDLK_HASH: return 0x29;
+	 case SDLK_DOLLAR: return 0x1B;
+	 case SDLK_AMPERSAND: return 0x02;
+	 /*case SDLK_QUOTE: return 0x28;*/
+	 /*case SDLK_PLUS: return 0x4E;*/
+	 /*case SDLK_MINUS: return 0x0C;*/
+	 case SDLK_SLASH: return 0x35;
+	 case SDLK_SEMICOLON: return 0x27;
+	 case SDLK_EQUALS: return 0x0D;
+	 case SDLK_GREATER: return 0x34;
+	 case SDLK_QUESTION: return 0x35;
+	 case SDLK_AT: return 0x28;
+	 case SDLK_CARET: return 0x2B;
+	 /* TODO not yet reviewed. The cases above ensure no changes from Thomas Huth's default map and should be re-evaluated on review. -- Brad Smith */
 	 case SDLK_QUOTE: return 0x0D;
 	 case SDLK_PLUS: return 0x0C;
 	 case SDLK_MINUS: return 0x35;
@@ -477,9 +507,24 @@ static uint8_t Keymap_SymbolicToStScanCode_DK(const SDL_Keysym* keysym)
 
 static uint8_t Keymap_SymbolicToStScanCode_NL(const SDL_Keysym* keysym)
 {
-	/* TODO not yet reviewed. -- Brad Smith */
 	switch (keysym->sym)
 	{
+	 case SDLK_EXCLAIM: return 0x09;
+	 case SDLK_QUOTEDBL: return 0x04;
+	 /*case SDLK_HASH: return 0x29;*/
+	 case SDLK_DOLLAR: return 0x1B;
+	 case SDLK_AMPERSAND: return 0x02;
+	 case SDLK_QUOTE: return 0x28;
+	 case SDLK_PLUS: return 0x4E;
+	 case SDLK_MINUS: return 0x0C;
+	 case SDLK_SLASH: return 0x35;
+	 case SDLK_SEMICOLON: return 0x27;
+	 case SDLK_EQUALS: return 0x0D;
+	 case SDLK_GREATER: return 0x34;
+	 case SDLK_QUESTION: return 0x35;
+	 case SDLK_AT: return 0x28;
+	 case SDLK_CARET: return 0x2B;
+	 /* TODO not yet reviewed. The cases above ensure no changes from Thomas Huth's default map and should be re-evaluated on review. -- Brad Smith */
 	 case SDLK_HASH: return 0x2B;
 	 case SDLK_BACKSLASH: return 0x60;
 	 default: return Keymap_SymbolicToStScanCode_default(keysym);


### PR DESCRIPTION
**This PR has been relocated from here at the maintainer's request: https://github.com/hatari/hatari/pull/36**

**The PR's commentary has been duplicated below:**

It seems that my work in progress on the per-region TOS symbolic keyboard mappings was reorganized and integrated yesterday. For reference, this was that work in progress:

Comparison: https://github.com/bbbradsmith/hatari_hatari/compare/tos-symbolic-compare..bbbradsmith:hatari_hatari:tos-symbolic

I've reviewed the changes, and I've found a lot was omitted or altered, I think some errors were made. I have revised it and tested it to prepare this PR. My notes follow:

- Trying to put a clear comment about every assignment that is arbitrary or unusual, indicating both what host layout it's from, and what ST key it's mapped to. List all regions involved, not just one.
- I had avoided having a separate "default" keymap below US, because I was because I was trying to reduce the number of arbitrary decisions we have to maintain here, and because I was treating each layout as a complete set, not overlays to a fallback routine like this. However, if we wish to do this, I think that is OK, but I have some commentary and suggestions:
  - I've added comments to the individual region code to indicate which arbitrary additions to the default are being relied upon, so that if we need to maintain one we can see better what is affected.
  - The point of the "default" should be to reduce code, so I think when making arbitrary decisions we should pick the ST scancode which applies to the most maps, resulting in fewest overrides. This is not the same as deciding "only XXX language has this key, so the default must be for XXX host and XXX TOS", which leads to frustratingly arbitrary choices about which language priority, and that's precisely what inspired me to do this in the first place, so we wouldn't have to have arguments about whether German minus is more "default" than US minus.
    - Each language will be an override on the default, so the "default" set really only has code significance, and this arbitrary "default" choice will not impact the user in any way. Therefore: pick the scancode which will result in the fewest overrides.
    - Some keys only belong to one host language, however this is a symbolic SDL mapping from any host keyboard to a specific ST TOS language. So, even if a key belongs to one host only, it may still have valid mappings on other TOS languages. Therefore, defer to the fewest-overrides note above. This should apply to all keys with an SDLK_* semantic enumeration.
    - When a key belongs to only one host language and has no natural mappings to other ST TOS languages, there we can use that language's ST code as a default. This should be limited to just those extra symbols which have no SDLK semantic enumeration.
  - SDLK_EXCLAIM mapped to 0x09 with the comment "on azerty?". I believe this is only present on FR host, but the majority of TOS will map to 0x02. However, additional note about French: there are 3 keys on the FR ST keyboard which have no natural correspondence with the FR AZERTY host keyboard. Because of this there were 3 keys I assigned an arbitrary mapping, so that it is always possible to press every FR ST key from a standard FR AZERTY host keyboard. This key was assigned to 0x0D. Explanation here: https://listengine.tuxfamily.org/lists.tuxfamily.org/hatari-devel/2024/02/msg00050.html
  - SDL_QUOTEDBL present on FR host only, I believe, but the majority is 0x03.
  - SDLK_HASH present on DE, UK only, but the majority is 0x2B.
  - SDLK_DOLLAR present on CHFR, CHDE only, but majority is 0x05.
  - SDLK_AMPERSAND is not something I see on AZERTY, not sure what host has this, but the majority is 0x07.
  - SDLK_QUOTE the majority is 0x0C.
  - SDLK_PLUS 0x43 is the wrong semantic mapping, this is not KP_PLUS. Majority is 0x0D.
  - SDLK_MINUS majority is 0x35.
  - SDLK_SLASH majority is 0x08.
  - SDLK_SEMICOLON majority is 0x33.
  - SDLK_EQUALS majority ix 0x0B.
  - SDLK_GREATER majority is 0x60.
  - SDLK_QUESTION majority is 0x0C.
  - SDLK_UNDERSCORE majority is 0x35.
  - SDLK_KP_EQUALS is a numpad key with no natural mapping. 0x61 (ST Undo) was chosen with no comment, which feels like a mistake. Changing it to 0x72 as a duplicate of KP_ENTER but if this wasn't a mistake it should have an explicit comment indicating that it's for Undo.
  - Finally, the default fallback in Keymap_SetCountry must be a specific mapping, not a "default" that is an arbitrary combination of mismatched elements. I suggest US as the default, just because historically the default mapping was essentially US already.
- Spanish international fallback differences, these are not in conflict so I suggest keeping both, but we may have tested slightly different layouts?
  - 161 was missing from yours, ¡ on the ES layout I tested, mapped to ST °§. It's an arbitrary mapping, but ¡¿ on a Spanish host keyboard has no natural mapping to ST which has them on 1 and 2, and ST °§ is otherwise inaccessible by any natural mapping.
  - 176 was missing from mine, not on the ES layout I tested (º in your comment), mapped to ST \.
  - 186 was missing from yours, º on the ES layout I tested, mapped to ST \.
- French international differences seem to conflict with mine, and I can't reconcile your differences with my research. These all had valid key mappings for other keyboards already, but not the AZERTY French layout I tested. I can only seem to find them in reference for the BÉPO French variant, and not AZERTY, and all of them are redundant to the top row numeral keys anyway. I've added them instead as redundances in the FR symbolic map instead, and restored the conflicted fallbacks to more appropriate languages. Please comment on whether I have made an incorrect assumption here:
  - 224 à in IT/CHFR.
  - 231 Ç in ES.
  - 232 è in IT/CHFR.
  - 233 é in CHFR.
  - AZERTY FR reference: http://www.kbdlayout.info/kbdfrna
  - BÉPO FR reference: http://www.kbdlayout.info/kbdfrnb
- US mapping completely absent from code? This needed to be recreated. The "default" mapping had been changed significantly from a proper US mapping already before I instigated the "majority" rule.
- DE mapping missing overrides: SDLK_QUOTE, SDLK_AT, SDLK_CARET, SDLK_UNDERSCORE, SDLK_BACKQUOTE, SDLK_LEFTBRACKET,SDLK_BACKSLASH, SDLK_RIGHTBRACKET, SDLK_CARET, SDLK_UNDERSCORE, SDLK_BACKQUOTE.
- FR mapping:
  - SDLK_ASTERISK, 178, 249 as noted above.
  - Missing overrides: SDLK_PLUS, SDLK_PERIOD, SDLK_SLASH, SDLK_QUESTION, SDLK_BACKSLASH, SDLK_UNDERSCORE.
  - Override for 167 seems to be from CHFR host keyboard, noting it.
  - 224, 231, 232, 233 assumed as BÉPO only, added as FR only override rather than replacing important defaults belonging to other languages as noted above.
- UK mapping missing overrides: SDLK_AMPERSAND, SDLK_COLON, SDLK_LESS, SDLK_BACKSLASH, SDLK_CARET.
- ES mapping missing overrides: SDLK_QUOTEDBL, SDLK_AMPERSAND, SDLK_QUOTE, SDLK_SLASH, SDLK_COLON, SDLK_QUESTION, SDLK_CARET
- IT mapping missing overrides: SDLK_HASH, SDLK_AT, SDLK_UNDERSCORE, SDLK_BACKQUOTE
- SE mappings:
  - Missing overrides: SDLK_HASH, SDLK_ASTERISK, SDLK_UNDERSCORE, SDLK_BACKQUOTE
  - 252 override is valid, but not present on SE host keyboards. Making comment to note this.
  - Like French I added one arbitrary mapping for a SE host keyboard that doesn't have a natural ST mapping and would be unpressable. 167 SE § as ST \.
- CH mappings: SDLK_EXCLAIM, SDLK_HASH, SDLK_DOLLAR, SDLK_ASTERISK, SDLK_PLUS, SDLK_AT, SDLK_RIGHTBRACKET, SDLK_UNDERSCORE, SDLK_BACKQUOTE

I'll try to finish my research for FI, NO, DK, SA, NL, CS, HU so that I can compare against and review what you've added for some of those, and maybe supplement the rest if I can.
